### PR TITLE
Add Renovate Dashboard issue and use lockFileMaintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,8 @@
 {
   "extends": ["config:base"],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "automerge": true
   },
-  "dependencyDashboard": true,
-  "packageRules": [
-    {
-      "updateTypes": ["lockFileMaintenance"],
-      "automerge": true
-    }
-  ]
+  "dependencyDashboard": true
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,11 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "dependencyDashboard": true
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "updateTypes": ["lockFileMaintenance"],
+      "automerge": true
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,1 +1,7 @@
-{"extends": ["config:base"]}
+{
+  "extends": ["config:base"],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "dependencyDashboard": true
+}


### PR DESCRIPTION
## What changes?

- Enable Renovate dashboard
- Enable lockfile maintenance on Mondays
- Add basic automerge (see post below for some serious warnings, and ways to get proper advice)

## Why you might like these changes:

You can use the dashboard to get a overview of all that the bot's doing on your repository.
This is handy if you hold back updates (you can see all the updates you've held back in the dashboard).

The lock file maintenance ensures that your lockfile is kept up to date (if you use one).
By default Renovate will make a PR on Monday that updates the lockfile dependencies but you can adjust this schedule.

Let me know what you think. :wink: 

## Renovate documentation links:

[lockFileMaintenance](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance)
[dependencyDashboard](https://docs.renovatebot.com/configuration-options/#dependencydashboard)