### PR TITLE
docs(adr-init): initialized the `architecture-decisions` directory for ADRs

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+architecture-decisions/

--- a/architecture-decisions/0001-record-architecture-decisions.md
+++ b/architecture-decisions/0001-record-architecture-decisions.md
@@ -8,7 +8,7 @@ Accepted
 
 ## Context
 
-We need to record the architectural decisions made on this project.
+As we take steps to modernize CI and dependency updating, @gr2m and @travi have taken steps to discuss trade-offs of various options. During these discussions, the value of capturing the decisions from these discussions came up. Interest from both of us in ADRs was mentioned.
 
 ## Decision
 

--- a/architecture-decisions/0001-record-architecture-decisions.md
+++ b/architecture-decisions/0001-record-architecture-decisions.md
@@ -8,7 +8,7 @@ Accepted
 
 ## Context
 
-As we take steps to modernize CI and dependency updating, @gr2m and @travi have taken steps to discuss trade-offs of various options. During these discussions, the value of capturing the decisions from these discussions came up. Interest from both of us in ADRs was mentioned.
+As we take steps to modernize CI and dependency updating, [@gr2m](https://github.com/gr2m/) and [@travi](https://github.com/travi/) have taken steps to discuss trade-offs of various options. During these discussions, the value of capturing the decisions from these discussions came up. Interest from both of us in ADRs was mentioned.
 
 ## Decision
 

--- a/architecture-decisions/0001-record-architecture-decisions.md
+++ b/architecture-decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2020-11-16
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).


### PR DESCRIPTION
using the `adr init` command of `adr-tools` from https://github.com/npryce/adr-tools