### PR TITLE
docs(renovate-branches): define decision to not build renovate branches in test workflows

### DIFF
--- a/architecture-decisions/0002-avoid-building-renovate-branches.md
+++ b/architecture-decisions/0002-avoid-building-renovate-branches.md
@@ -1,0 +1,28 @@
+# 2. Avoid building renovate branches
+
+Date: 2020-11-16
+
+## Status
+
+Accepted
+
+## Context
+
+In order for renovate PR branches to be built in isolation, they could be
+included in the list under the `push` trigger in the test workflow as
+`renovate/**`. However, that would result in duplication for the builds
+triggered by the PR being opened or updated.
+
+These two build types are intended to catch differing problems between the
+isolated branch vs the branch merged with the mainline. However, as short-lived
+as the renovate PRs are intended to be, it should be rare that the results of
+the two builds are different.
+
+## Decision
+
+We will not build the renovate branches as part of the test wrokflows
+
+## Consequences
+
+Redundant builds will be avoided and we will rely on the PR builds to verify
+that the dependency updates are safe to merge

--- a/architecture-decisions/0002-avoid-building-renovate-branches.md
+++ b/architecture-decisions/0002-avoid-building-renovate-branches.md
@@ -20,9 +20,9 @@ the two builds are different.
 
 ## Decision
 
-We will not build the renovate branches as part of the test wrokflows
+We will not build the renovate branches as part of the test workflows.
 
 ## Consequences
 
 Redundant builds will be avoided and we will rely on the PR builds to verify
-that the dependency updates are safe to merge
+that the dependency updates are safe to merge.


### PR DESCRIPTION
initially implemented with https://github.com/semantic-release/github/pull/306

while this may already be a decision that we end up changing, based on https://github.com/semantic-release/.github/issues/3#issuecomment-728481665, we can follow up with another record that supersedes this decision 