### PR TITLE
chore: exclude pre-1.0.0 devDeps from automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
     {
       "depTypeList": ["devDependencies"],
       "automerge": true,
-      "automergeType": "branch"
+      "automergeType": "branch",
+      "matchCurrentVersion": "!/^0/"
     }
   ]
 }


### PR DESCRIPTION
## Changes:

- Exclude any development Dependencies that are pre-1.0.0 from being automerged

## Context:

The `matchCurrentVersion` setting is a rule to exclude any dependencies which are pre-1.0.0 because those can make breaking changes at _any_ time according to the SemVer spec.

I lifted the regular expression from the `automerge-configuration` docs that are being worked on in PR `#7724` at the `renovate/renovate` repository. I think this should work properly as the regex was written by the head maintainer of Renovate. :smile: 

This would also mean that you **do get a PR** for pre-1.0.0 development dependencies, even though post 1.0.0 dependencies are automerged. So that might be a little confusing.

It's up to you to decide if this is something you want. There's an argument to be made to keep things simple, but you might also want to prevent breakage by 0.x type devDependencies. I'll let you weigh up the pros/cons of this.