### PR TITLE
ci(settings): added initial settings that should be applied consistently across the org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/**     @semantic-release/maintainers

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,33 @@
+repository:
+  delete_branch_on_merge: true
+  has_wiki: false
+  has_projects: false
+  allow_squash_merge: true
+  allow_merge_commit: false
+  allow_rebase_merge: false
+
+branches:
+  - name: master
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        dismissal_restrictions: null
+      required_status_checks:
+        strict: false
+        contexts: ['test', 'WIP']
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        dismissal_restrictions: null
+      required_status_checks:
+        strict: false
+        contexts: ['test', 'WIP']
+
+teams:
+  - name: maintainers
+    permission: maintain


### PR DESCRIPTION
for #7

i think this could be merged as is, but it does have a few gaps that we will probably want to close with follow up changes:

* it does not define any labels because i would want to be very careful with what we define, if any. if the list does not include _all_ of the labels _already used_ in the repository, the ones that arent included _will be removed_ from the repository (even any existing issues/PRs that use them)
* it only grants permission for the `maintainers` team. i still wonder if there would be value in an admins or owners team, or maybe a triage or contributors team that we could define other permission levels for. then we could add other members to those teams in the future and have the permissions already granted. we can discuss and update later if we decide to add anything like that