### PR TITLE
fix(renovate): stopped using the branch merge strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,7 @@
   "packageRules": [
     {
       "depTypeList": ["devDependencies"],
-      "automerge": true,
-      "automergeType": "branch"
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
since it doesnt work when reviews are required, as describe in
https://docs.renovatebot.com/key-concepts/automerge/#branch-vs-pr-automerging