### PR TITLE
ci(renovate): enabled the dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "enabled": true,
     "automerge": true
   },
-  "dependencyDashboard": false,
+  "dependencyDashboard": true,
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies", "action"],


### PR DESCRIPTION
we discussed our initial config for this [here](https://github.com/semantic-release/.github/pull/1), but i think it may be time to reconsider. i've found the dashboard useful on my other projects for forcing certain things to happen. it is especially helpful when there are many update PRs already open, preventing some newer updates from resulting in PRs.