### PR TITLE
ci(renovate): configured to pin gh action digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base", ":pinOnlyDevDependencies"],
+  "extends": ["config:base", ":pinOnlyDevDependencies", "helpers:pinGitHubActionDigests"],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true


### PR DESCRIPTION
to mitigate the risk of mutability. for more details, see https://github.com/ossf/scorecard/blob/27cfe92ed356fdb5a398c919ad480817ea907808/docs/checks.md#pinned-dependencies