### PR TITLE
ci(renovate): defined a regex manager to update pinned semantic-release version in github workflows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,5 +20,14 @@
       "matchPackageNames": ["xo"],
       "allowedVersions": "<0.40.0"
     }
+  ],
+  "regexManagers": [
+    {
+      "description": "Update semantic-release version used by npx",
+      "fileMatch": ["^\\.github/workflows/release-package\\.yml$"],
+      "matchStrings": ["\\srun: npx semantic-release@(?<currentValue>.*?)\\s"],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "semantic-release"
+    }
   ]
 }


### PR DESCRIPTION
part of following our own advice from https://github.com/semantic-release/semantic-release/pull/2786. this will help keep from getting stale if we pin the version in our release workflows