### PR TITLE
ci(renovate): configured renovate to pin actions version comments

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,12 @@
       "automerge": true
     },
     {
+      "description": "v prefix workaround for action updates",
+      "matchDepTypes": ["action"],
+      "extractVersion": "^(?<version>v\\d+\\.\\d+\\.\\d+)$",
+      "versioning": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
+    },
+    {
       "depTypeList": ["action"],
       "semanticCommitType": "ci",
       "semanticCommitScope": "action"


### PR DESCRIPTION
using workaround config until https://github.com/renovatebot/renovate/pull/23663 potentially moves forward

examples of the behavior this will enable: https://github.com/renovatebot/renovate/pull/23663#issuecomment-1707602564